### PR TITLE
Support for multiple databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # docker-cloudsqlproxy
 Google CloudSQL proxy service
+
+### Running with a single CloudSql DB
+When running with a single database, set the following environment vars:
+
+`GOOGLE_PROJECT`
+`CLOUDSQL_ZONE`
+`CLOUDSQL_INSTANCE`
+
+### Running with multiple CloudSql DBs
+When running with multiple databases, you must drop down to the lower level args from the proxy directly.  In this case, just use:
+
+`CLOUDSQL_INSTANCES`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,7 +100,7 @@ fi
 # if using a single instance, we construct instances arg
 if [ -n "${CLOUDSQL_INSTANCE}" ]
 then
-    INSTANCES="${GOOGLE_PROJECT}:${CLOUDSQL_INSTANCE}:${CLOUDSQL_ZONE}:${CLOUDSQL_INSTANCE}:tcp:0.0.0.0:3306"
+    INSTANCES="${GOOGLE_PROJECT}:${CLOUDSQL_ZONE}:${CLOUDSQL_INSTANCE}=tcp:0.0.0.0:3306"
 fi
 
 # if using multiple instances, we just pass the instances arg through

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,24 +54,26 @@ fi
 
 # validate required vars are set
 
-if [ -z "${GOOGLE_PROJECT}" ]
+# for single instance, need the project.
+if [ -z "${GOOGLE_PROJECT}" ] && [ -n "${CLOUDSQL_INSTANCE}" ]
 then
    MISSING="GOOGLE_PROJECT ${MISSING}"
 fi
 
-if [ -z "${CLOUDSQL_ZONE}" ]
+# need the zone if you're using a single instance
+if [ -z "${CLOUDSQL_ZONE}" ] && [ -n "${CLOUDSQL_INSTANCE}" ]
 then
    MISSING="CLOUDSQL_ZONE ${MISSING}"
 fi
 
 # need xor singular cloudsql instance or multiple cloudsql instances
-if [ -z "${CLOUDSQL_INSTANCE}" && -z "${CLOUDSQL_INSTANCES}" ]
+if [ -z "${CLOUDSQL_INSTANCE}" ] && [ -z "${CLOUDSQL_INSTANCES}" ]
 then
    MISSING="CLOUDSQL_INSTANCE ${MISSING}"
 fi
 
 # if both singular instance and multiple instance are set, that's a problem
-if [ "${CLOUDSQL_INSTANCE}" && "${CLOUDSQL_INSTANCES}" ]
+if [ -n "${CLOUDSQL_INSTANCE}" ] && [ -n "${CLOUDSQL_INSTANCES}" ]
 then
    MISSING="CLOUDSQL_INSTANCE ${MISSING}"
 fi
@@ -95,11 +97,15 @@ then
    exit 1
 fi
 
-INSTANCES="${GOOGLE_PROJECT}:${CLOUDSQL_ZONE}"
-if ["${CLOUDSQL_INSTANCE}"]
-    INSTANCES="${CLOUDSQL_INSTANCE}:tcp:0.0.0.0:3306"
+# if using a single instance, we construct instances arg
+if [ -n "${CLOUDSQL_INSTANCE}" ]
+then
+    INSTANCES="${GOOGLE_PROJECT}:${CLOUDSQL_INSTANCE}:${CLOUDSQL_ZONE}:${CLOUDSQL_INSTANCE}:tcp:0.0.0.0:3306"
 fi
-if ["${CLOUDSQL_INSTANCES}"]
+
+# if using multiple instances, we just pass the instances arg through
+if [ -n "${CLOUDSQL_INSTANCES}" ]
+then
     INSTANCES="${CLOUDSQL_INSTANCES}"
 fi
 


### PR DESCRIPTION
DDP uses multiple databases, so this PR adds the ability to specify multiple databases using a new `CLOUDSQL_INSTANCES` environment variable.  The contents of this variable are the lower level google syntax for the proxy.

I added some sanity checking in the startup script to help avoid clashing of `CLOUDSQL_INSTANCES` and `CLOUDSQL_INSTANCE`, and also added some checks so that the required fields are only required when using the singular `CLOUDSQL_INSTANCE`.

Please test this with some existing clients that use `CLOUDSQL_INSTANCE`--I've done some cursory checks to ensure that things don't appear totally broken, but not exhaustive!