### PR TITLE
[DDO-3023] Fix bumper

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         env:
           DEFAULT_BUMP: patch
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-          RELEASE_BRANCHES: ${{ github.event.repository.default_branch }}
+          RELEASE_BRANCHES: main
 
       # GCP config
       - name: Auth to GCP


### PR DESCRIPTION
For whatever reason, `${{ github.event.repository.default_branch }}` does not seem to be set to `main` on post-merge push events. Witness this action, which ran on main but published a pre-release tag: https://github.com/broadinstitute/docker-cloudsqlproxy/actions/runs/5764779868