### PR TITLE
[DDO-3419] Fix non-prod access + formatting

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,13 +5,13 @@ set -o pipefail
 
 # wrapper script for cloud_sql_proxy program
 
-# By using this entrypoint script in the docker image it provides a much 
-#  simplier method of running the proxy.  Instead of having to specify the 
+# By using this entrypoint script in the docker image it provides a much
+#  simpler method of running the proxy.  Instead of having to specify the
 #  exact sqlproxy command via the CMD or run - you are able to just set
 #  environment variables for the various settings
 #
-# This script assumes you will be using a service account as authenticaiton
-#  either by mounting the sevice account json into the docker container or 
+# This script assumes you will be using a service account as authentication
+#  either by mounting the service account json into the docker container or
 #  setting the appropriate role on the default service account
 
 MISSING=""
@@ -79,7 +79,7 @@ eval set -- "$TEMP"
 while true ; do
     case "$1" in
         -v|--version)
-             version 
+             version
              exit 1
            ;;
         -h|--help)
@@ -123,14 +123,14 @@ then
       echo
       for miss in ${MISSING}
       do
-         case $miss in 
+         case $miss in
            "GOOGLE_PROJECT") echo "  GOOGLE_PROJECT: Google project name that CloudSQL instance resides"
              ;;
            "CLOUDSQL_ZONE") echo "  CLOUDSQL_ZONE: Google zone that instance resides in (us-central1-a, us-east1-b,..."
              ;;
            "CLOUDSQL_INSTANCE") echo "  CLOUDSQL_INSTANCE: Specific name of the CLoudSQL instance"
              ;;
-         esac 
+         esac
       done
       usage
       echo ; echo "Exitting!"
@@ -141,17 +141,17 @@ then
    CLOUDSQL_CONNECTION_LIST="${GOOGLE_PROJECT}:${CLOUDSQL_ZONE}:${CLOUDSQL_INSTANCE}=tcp:0.0.0.0:${PORT}"
 
 fi
-   
+
 # determine what credentials will be used if flag not set then use a service
 #  account json file.
 if [ "${CLOUDSQL_USE_DEFAULT_CREDENTIALS}" -eq "0" ]
 then
-   if [ -r ${CLOUDSQL_CREDENTIAL_FILE} ]
+   if [ -f ${CLOUDSQL_CREDENTIAL_FILE} ]
    then
       CREDENTIALS="-credential_file=${CLOUDSQL_CREDENTIAL_FILE}"
    else
-      echo "Unable to read credential file: (${CLOUDSQL_CREDENTIAL_FILE})! - Exitting"
-      echo 
+      echo "Unable to read credential file: (${CLOUDSQL_CREDENTIAL_FILE})! - Exiting"
+      echo
       exit 1
    fi
 fi


### PR DESCRIPTION
Instead of checking for read access, check the service account credentials file to see if it exists. This needs to happen because `entrypoint.sh` is run as `nonroot`, but volumes are mounted as `root`. I confirmed that this works locally by connecting to the Sam Dev database.

https://broadworkbench.atlassian.net/browse/DDO-3419